### PR TITLE
Migrated component-test blueprint generator from frost-core

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
+blueprints/component/files/**/*
+blueprints/component-test/files/**/*
 bower_components/**/*
 dist/**/*
 node_modules/**/*

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -1,0 +1,63 @@
+/**
+ * <%= capitalizedTestType %> test for the <%= dasherizedModuleName %> component
+ */
+
+import {expect} from 'chai'
+import {describeComponent, it} from 'ember-mocha'
+<% if (testType === 'integration' ) { %>import hbs from 'htmlbars-inline-precompile'
+import {$hook, initialize as initializeHook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {afterEach, beforeEach, describe} from 'mocha'<% } else { %>
+import {afterEach, beforeEach, describe} from 'mocha'<% } %>
+import sinon from 'sinon'
+
+import {<%= testType %>} from '<%= dasherizedPackageName %>/tests/helpers/ember-test-utils/describe-component'
+
+describeComponent(...<%= testType %>('<%= dasherizedModuleName %>'), function () {
+  <% if (testType === 'unit' ) { %>let component, sandbox<% } else { %>let sandbox<% } %>
+
+  beforeEach(function () {
+    <% if (testType === 'integration') { %>sandbox = sinon.sandbox.create()
+    initializeHook()<% } else { %>sandbox = sinon.sandbox.create()<% } %>
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+
+  <% if (testType === 'integration' ) { %>describe('after render', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myThing'
+      })
+
+      this.render(hbs`
+        {{<%= dasherizedModuleName %>
+          hook=myHook
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should have an element', function () {
+      expect(this.$()).to.have.length(1)
+    })
+
+    it('should be accessible via the hook', function () {
+      expect($hook('myThing')).to.have.length(1)
+    })
+  })<% } else { %>describe('when hook is given', function () {
+    beforeEach(function () {
+      component = this.subject({hook: 'myHook'})
+    })
+
+    it('should set hookPrefix', function () {
+      expect(component.get('hookPrefix')).to.equal('myHook-')
+    })
+  })<% } %>
+})

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -1,0 +1,75 @@
+/**
+ * Blueprint for generating a test for a frost component
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ * Pretty much taken outright from https://github.com/emberjs/ember.js/blob/master/blueprints/component-test/index.js
+ */
+
+'use strict'
+
+const getPathOption = require('ember-cli-get-component-path-option')
+const stringUtil = require('ember-cli-string-utils')
+
+const utils = require('../utils')
+
+module.exports = {
+  description: 'Generates a frost component integration or unit test using mocha.',
+
+  availableOptions: [
+    {
+      name: 'test-type',
+      type: ['integration', 'unit'],
+      default: 'integration',
+      aliases: [
+        {'i': 'integration'},
+        {'u': 'unit'},
+        {'integration': 'integration'},
+        {'unit': 'unit'}
+      ]
+    }
+  ],
+
+  /**
+   * Blueprint hook
+   * @see {@link https://ember-cli.com/extending/#filemaptokens}
+   *
+   * @returns {Object} custom tokens to be replaced in your files
+   */
+  fileMapTokens () {
+    return {
+      __path__: utils.component.fileMapTokens.path,
+
+      /**
+       * @param {Object} options - the options for the ember generate command
+       * @returns {String} the type of test (unit|integration)
+       */
+      __testType__ (options) {
+        return options.locals.testType || 'integration'
+      }
+    }
+  },
+
+  /**
+   * Blueprint hook
+   * @see {@link https://ember-cli.com/extending/#locals}
+   * @param {Object} options - the options for the ember generate command
+   * @returns {Object|Promise} a set of custom template variables or a Promise that resolves with the set
+   */
+  locals (options) {
+    const dasherizedModuleName = stringUtil.dasherize(options.entity.name)
+    let componentPathName = dasherizedModuleName
+    const testType = options.testType || 'integration'
+
+    if (options.pod && options.path !== 'components' && options.path !== '') {
+      componentPathName = [options.path, dasherizedModuleName].join('/')
+    }
+
+    return {
+      capitalizedTestType: stringUtil.capitalize(testType),
+      componentPathName,
+      path: getPathOption(options),
+      testType
+    }
+  },
+
+  normalizeEntityName: utils.component.normalizeEntityName
+}

--- a/blueprints/utils.js
+++ b/blueprints/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Shared functions used in multiple blueprints
+ */
+
+'use strict'
+
+const normalizeEntityName = require('ember-cli-normalize-entity-name')
+const validComponentName = require('ember-cli-valid-component-name')
+const path = require('path')
+
+module.exports = {
+  component: {
+    fileMapTokens: {
+      /**
+       * @param {Object} options - the options for the ember generate command
+       * @returns {String} the path for the component being generated
+       */
+      path (options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.locals.path, options.dasherizedModuleName)
+        }
+        return 'components'
+      }
+    },
+
+    /**
+     * Blueprint hook
+     * @see {@link https://ember-cli.com/extending/#normalizeentityname}
+     * @param {String} entityName - the requested name
+     * @returns {String} the normalized, validated entity name (must be a valid component name)
+     */
+    normalizeEntityName (entityName) {
+      entityName = normalizeEntityName(entityName)
+      return validComponentName(entityName)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,11 @@
     "testing"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-get-component-path-option": "1.0.0",
+    "ember-cli-normalize-entity-name": "^1.0.0",
+    "ember-cli-string-utils": "^1.0.0",
+    "ember-cli-valid-component-name": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [X] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** component-test blueprint generator
