### PR TITLE
Update blueprints and readme

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
-blueprints/component/files/**/*
-blueprints/component-test/files/**/*
+blueprints/*/files/**/*
 bower_components/**/*
 dist/**/*
 node_modules/**/*

--- a/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/adapter-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,35 @@
+/**
+ * Unit test for the <%= dasherizedModuleName %> adapter
+ */
+
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {module} from '<%= testHelpersPath %>/ember-test-utils/setup-test'
+
+// To specify the other units that are required for this test:
+// const test = module('adapter:<%= dasherizedModuleName %>', ['model:foo'])
+const test = module('adapter:<%= dasherizedModuleName %>')
+describe(test.label, function () {
+  test.setup()
+
+  let sandbox, adapter
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    adapter = this.subject()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should exist', function () {
+    expect(adapter).not.to.equal(undefined)
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+})

--- a/blueprints/adapter-test/index.js
+++ b/blueprints/adapter-test/index.js
@@ -1,0 +1,8 @@
+/**
+ * Blueprint for generating a test for a frost ember-data adapter
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ */
+
+module.exports = {
+  description: 'Generates a frosty ember-data adapter unit test'
+}

--- a/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/files/tests/__testType__/__path__/__test__.js
@@ -3,22 +3,23 @@
  */
 
 import {expect} from 'chai'
-import {describeComponent, it} from 'ember-mocha'
 <% if (testType === 'integration' ) { %>import hbs from 'htmlbars-inline-precompile'
-import {$hook, initialize as initializeHook} from 'ember-hook'
+import {$hook} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
-import {afterEach, beforeEach, describe} from 'mocha'<% } else { %>
-import {afterEach, beforeEach, describe} from 'mocha'<% } %>
+import {afterEach, beforeEach, describe, it} from 'mocha'<% } else { %>
+import {afterEach, beforeEach, describe, it} from 'mocha'<% } %>
 import sinon from 'sinon'
 
-import {<%= testType %>} from '<%= dasherizedPackageName %>/tests/helpers/ember-test-utils/describe-component'
+import {<%= testType %>} from '<%= testHelpersPath %>/ember-test-utils/setup-component-test'
 
-describeComponent(...<%= testType %>('<%= dasherizedModuleName %>'), function () {
+const test = <%= testType %>('<%= dasherizedModuleName %>')
+describe(test.label, function () {
+  test.setup()
+
   <% if (testType === 'unit' ) { %>let component, sandbox<% } else { %>let sandbox<% } %>
 
   beforeEach(function () {
-    <% if (testType === 'integration') { %>sandbox = sinon.sandbox.create()
-    initializeHook()<% } else { %>sandbox = sinon.sandbox.create()<% } %>
+    sandbox = sinon.sandbox.create()
   })
 
   afterEach(function () {

--- a/blueprints/component-test/index.js
+++ b/blueprints/component-test/index.js
@@ -56,6 +56,7 @@ module.exports = {
    */
   locals (options) {
     const dasherizedModuleName = stringUtil.dasherize(options.entity.name)
+    const dasherizedProjectName = stringUtil.dasherize(options.project.name())
     let componentPathName = dasherizedModuleName
     const testType = options.testType || 'integration'
 
@@ -63,10 +64,14 @@ module.exports = {
       componentPathName = [options.path, dasherizedModuleName].join('/')
     }
 
+    const isAddon = this.project.isEmberCLIAddon()
+    let testHelpersPath = isAddon ? 'dummy/tests/helpers' : `${dasherizedProjectName}/tests/helpers`
+
     return {
       capitalizedTestType: stringUtil.capitalize(testType),
       componentPathName,
       path: getPathOption(options),
+      testHelpersPath,
       testType
     }
   },

--- a/blueprints/controller-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/controller-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,35 @@
+/**
+ * Unit test for the <%= dasherizedModuleName %> controller
+ */
+
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {controller} from '<%= testHelpersPath %>/ember-test-utils/setup-test'
+
+// To specify the other units that are required for this test:
+// const test = controller('<%= dasherizedModuleName %>', ['route:<%= dasherizedModuleName %>'])
+const test = controller('<%= dasherizedModuleName %>')
+describe(test.label, function () {
+  test.setup()
+
+  let sandbox, controller
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    controller = this.subject()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should exist', function () {
+    expect(controller).not.to.equal(undefined)
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+})

--- a/blueprints/controller-test/index.js
+++ b/blueprints/controller-test/index.js
@@ -1,0 +1,8 @@
+/**
+ * Blueprint for generating a test for a frost controller
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ */
+
+module.exports = {
+  description: 'Generates a frosty controller unit test.'
+}

--- a/blueprints/ember-frost-test/index.js
+++ b/blueprints/ember-frost-test/index.js
@@ -1,13 +1,104 @@
+/**
+ * Install blueprint for ember-frost-test addon
+ */
+
+var chalk = require('chalk')
+var EOL = require('os').EOL
+
 module.exports = {
+
+  /**
+   * Add sinon-chai and chai-jquery bower libraries during testing
+   * @returns {Promise} a promise when the `ember-cli-build.js` file has been updated
+   */
+  addLoadingOfTestHelpers: function () {
+    const content =
+      '  if (app.env === \'test\') {' + EOL +
+      '    ;[' + EOL +
+      '      \'bower_components/sinon-chai/lib/sinon-chai.js\',' + EOL +
+      '      \'bower_components/chai-jquery/chai-jquery.js\'' + EOL +
+      '    ].forEach((path) => {' + EOL +
+      '      app.import(path, {type: \'test\'})' + EOL +
+      '    })' + EOL +
+      '  }' + EOL
+
+    return this.insertIntoFile('ember-cli-build.js', content, {
+      before: '  return app.toTree()' + EOL
+    })
+  },
+
+  /**
+   * This very hacky workaround is to solve the following problem:
+   * @see {@link https://github.com/testem/testem/issues/1043}
+   * We install a specific version of `testem` (currently from github.com/job13er/testem#ember-frost-test)
+   * But `ember-cli` will still have it's own version, so we need to create a `postinstall` npm script that will
+   * remove the `node_modules/ember-cli/node_modules/testem` directory, letting `ember-cli` use the
+   * `node_modules/testem` version instead.
+   *
+   * NOTE: once https://github.com/testem/testem/pull/1045 is merged/released and the version of `ember-cli`
+   * we are using is picking it up, we can remove this and switch to something that makes sure that particular
+   * script is gone.
+   *
+   * @returns {Promise} a promise when the `package.json` file has been updated
+   */
+  addPostInstallScript: function () {
+    const content = '    "postinstall": "rm -rf node_modules/ember-cli/node_modules/testem",'
+    return this.insertIntoFile('package.json', content, {
+      after: '  "scripts": {' + EOL
+    })
+  },
+
+  /**
+   * This very hacky workaround since specifying a packaged as github org / repo doesn't seem to update
+   * `package.json` properly, so in the meantime we just add it to `devDependencies` manually
+   *
+   * @returns {Promise} a promise when the `package.json` file has been updated
+   */
+  addTestemDepToPackageJson: function () {
+    const content = '    "testem": "job13er/testem#ember-frost-test",'
+    return this.insertIntoFile('package.json', content, {
+      after: '  "devDependencies": {' + EOL
+    })
+  },
+
   afterInstall: function () {
-    return this.addAddonsToProject({
+    const addonsToAdd = {
       packages: [
-        {name: 'ember-cli-mocha', target: '^0.11.0'},
+        {name: 'ember-cli-mocha', target: '^0.13.0'},
         {name: 'ember-hook', target: '^1.3.5'},
         {name: 'ember-sinon', target: '~0.5.0'},
-        {name: 'ember-test-utils', target: '^1.1.2'}
+        {name: 'ember-test-utils', target: '^1.3.2'}
       ]
-    })
+    }
+
+    const npmPackagesToAdd = [
+      {name: 'job13er/testem#ember-frost-test'}
+    ]
+
+    const bowerPackagesToAdd = [
+      {name: 'sinon-chai', target: '^2.8.0'},
+      {name: 'chai-jquery', target: '^2.0.1'}
+    ]
+
+    return this.addAddonsToProject(addonsToAdd)
+      .then(() => {
+        return this.addPackagesToProject(npmPackagesToAdd)
+      })
+      .then(() => {
+        this.ui.writeLine(chalk.green('Updating') + ' "package.json" to include forked "testem" (for now)')
+        return this.addTestemDepToPackageJson()
+      })
+      .then(() => {
+        return this.addBowerPackagesToProject(bowerPackagesToAdd)
+      })
+      .then(() => {
+        this.ui.writeLine(chalk.green('Updating') + ' "ember-cli-build.js" to load "sinon-chai" and "chai-jquery"')
+        return this.addLoadingOfTestHelpers()
+      })
+      .then(() => {
+        this.ui.writeLine(chalk.green('Updateing') + ' "package.json" with "postinstall" script')
+        return this.addPostInstallScript()
+      })
   },
 
   normalizeEntityName: function () {

--- a/blueprints/ember-frost-test/index.js
+++ b/blueprints/ember-frost-test/index.js
@@ -13,12 +13,12 @@ module.exports = {
    */
   addLoadingOfTestHelpers: function () {
     const content =
-      '  if (app.env === \'test\') {' + EOL +
+      '  if ([\'test\', \'development\'].includes(app.env)) {' + EOL +
       '    ;[' + EOL +
       '      \'bower_components/sinon-chai/lib/sinon-chai.js\',' + EOL +
       '      \'bower_components/chai-jquery/chai-jquery.js\'' + EOL +
       '    ].forEach((path) => {' + EOL +
-      '      app.import(path, {type: \'test\'})' + EOL +
+      '      app.import(path)' + EOL +
       '    })' + EOL +
       '  }' + EOL
 
@@ -96,7 +96,7 @@ module.exports = {
         return this.addLoadingOfTestHelpers()
       })
       .then(() => {
-        this.ui.writeLine(chalk.green('Updateing') + ' "package.json" with "postinstall" script')
+        this.ui.writeLine(chalk.green('Updating') + ' "package.json" with "postinstall" script')
         return this.addPostInstallScript()
       })
   },

--- a/blueprints/mixin-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/mixin-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,30 @@
+/**
+ * Unit test for the <%= dasherizedModuleName %> mixin
+ */
+
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>'
+
+describe('Unit / Mixin / <%= dasherizedModuleName %> /', function () {
+  let sandbox, subject
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    subject = Ember.Object.extend(<%= classifiedModuleName %>Mixin).create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should exist', function () {
+    expect(subject).not.to.equal(undefined)
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+})

--- a/blueprints/mixin-test/index.js
+++ b/blueprints/mixin-test/index.js
@@ -1,0 +1,8 @@
+/**
+ * Blueprint for generating a test for a frost mixin
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ */
+
+module.exports = {
+  description: 'Generates a frosty mixin unit test.'
+}

--- a/blueprints/model-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/model-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,35 @@
+/**
+ * Unit test for the <%= dasherizedModuleName %> model
+ */
+
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {model} from '<%= testHelpersPath %>/ember-test-utils/setup-test'
+
+// To specify the other units that are required for this test:
+// const test = model('<%= dasherizedModuleName %>', ['model:fizz-bang'])
+const test = model('<%= dasherizedModuleName %>')
+describe(test.label, function () {
+  test.setup()
+
+  let sandbox, instance
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    instance = this.subject()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should exist', function () {
+    expect(instance).not.to.equal(undefined)
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+})

--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,8 +1,8 @@
 /**
- * Blueprint for generating a test for a frost ember-data adapter
+ * Blueprint for generating a test for a frost ember-data model
  * NOTE: this is run in node, not in ember stack, so limited es6 is available
  */
 
 module.exports = {
-  description: 'Generates a frosty ember-data adapter unit test'
+  description: 'Generates a frosty ember-data model unit test'
 }

--- a/blueprints/model-test/index.js
+++ b/blueprints/model-test/index.js
@@ -1,0 +1,8 @@
+/**
+ * Blueprint for generating a test for a frost ember-data adapter
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ */
+
+module.exports = {
+  description: 'Generates a frosty ember-data adapter unit test'
+}

--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,35 @@
+/**
+ * Unit test for the <%= dasherizedModuleName %> route
+ */
+
+import {expect} from 'chai'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
+
+import {route} from '<%= testHelpersPath %>/ember-test-utils/setup-test'
+
+// To specify the other units that are required for this test:
+// const test = route('<%= dasherizedModuleName %>', ['controller:<%= dasherizedModuleName %>'])
+const test = route('<%= dasherizedModuleName %>')
+describe(test.label, function () {
+  test.setup()
+
+  let sandbox, route
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    route = this.subject()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should exist', function () {
+    expect(route).not.to.equal(undefined)
+  })
+
+  it('should have real tests', function () {
+    expect(true).to.equal(false)
+  })
+})

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,0 +1,8 @@
+/**
+ * Blueprint for generating a test for a frost route
+ * NOTE: this is run in node, not in ember stack, so limited es6 is available
+ */
+
+module.exports = {
+  description: 'Generates a frosty route unit test.'
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-frost-test",
   "version": "0.1.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "The place for all the frosty testing things",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,7 +11,8 @@
     "lint": "npm run lint-js",
     "lint-js": "eslint addon app blueprints config tests *.js",
     "start": "ember server",
-    "test": "npm run lint && ember test"
+    "test": "npm run lint && ember test",
+    "postinstall": "rm -rf node_modules/ember-cli/node_modules/testem"
   },
   "repository": {
     "type": "git",
@@ -21,23 +22,26 @@
     "node": ">= 6.0.0"
   },
   "author": "Michael Carroll (https://github.com/juwara0)",
+  "contributors": [
+    "Adam Meadows (https://github.com/job13er)"
+  ],
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "2.9.1",
+    "ember-cli": "~2.8.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-chai": "0.2.0",
+    "ember-cli-chai": "^0.3.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-mocha": "^0.11.0",
+    "ember-cli-mocha": "^0.13.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.9.0",
+    "ember-data": "~2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.3.5",
@@ -47,8 +51,9 @@
     "ember-test-utils": "^1.1.2",
     "ember-welcome-page": "^1.0.3",
     "eslint": "^3.0.0",
-    "eslint-config-frost-standard": "^4.0.0",
-    "loader.js": "^4.0.10"
+    "eslint-config-frost-standard": "^5.0.0",
+    "loader.js": "^4.0.10",
+    "testem": "job13er/testem#ember-frost-test"
   },
   "keywords": [
     "ember-addon",
@@ -63,6 +68,7 @@
     "ember-cli-valid-component-name": "^1.0.0"
   },
   "ember-addon": {
+    "after": "ember-frost-core",
     "configPath": "tests/dummy/config"
   }
 }

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,5 @@
 module.exports = {
+  'debug': true,
   'framework': 'mocha',
   'test_page': 'tests/index.html?hidepassed',
   'disable_watching': true,
@@ -6,7 +7,6 @@ module.exports = {
     'Chrome'
   ],
   'launch_in_dev': [
-    'Firefox',
     'Chrome'
   ]
 }

--- a/tests/unit/fail-in-before-each-test.js
+++ b/tests/unit/fail-in-before-each-test.js
@@ -1,0 +1,30 @@
+/**
+ * This is a test that forces a failure in a beforeEach to make sure
+ * that it is properly reported. We were seeing an issue with the latest `ember-mocha` where
+ * testem wasn't reporting errors in this case
+ */
+
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+
+// TODO: un-skip this to confirm that mocha and testem are playing nice
+describe.skip('Outer test that passes', function () {
+  let foo
+  beforeEach(function () {
+    foo = 1
+  })
+
+  it('should pass', function () {
+    expect(foo).to.equal(1)
+  })
+
+  describe('Inner test with bad beforeEach', function () {
+    beforeEach(function () {
+      throw new Error('error in beforeEach')
+    })
+
+    it('should have failed before it got here', function () {
+      expect(foo).to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** the `README.md` with examples using the latest `ember-mocha` and `ember-test-utils` stuff
* **Added** a section in the `README.md` about how to structure `describe`, `beforeEach` and `it` blocks within tests.
* **Added** `adapter-test` blueprint for generating adapter tests
* **Added** `controller-test` blueprint for generating controller tests
* **Updated** `component-test` blueprint to use new helpers from `ember-test-utils`
* **Added** `mixin-test` blueprint for generating mixin tests
* **Added** `model-test` blueprint for generating model tests
* **Added** `route-test` blueprint for generating route tests
* **Updated** `ember-frost-test` blueprint to install a bugfix branch of `testem` and make sure it's used by `ember-cli` to workaround [this bug](https://github.com/testem/testem/issues/1043) until the fix is merged/released. 
* **Fixed** a bug in `component-test` where generating a test for an addon was using `addon-name/tests/helpers` instead of `dummy/tests/helpers` to pull in `ember-test-utils` helpers.