### PR TITLE
Remove ugly hack since testem fix was released

### DIFF
--- a/blueprints/ember-frost-test/index.js
+++ b/blueprints/ember-frost-test/index.js
@@ -6,7 +6,6 @@ var chalk = require('chalk')
 var EOL = require('os').EOL
 
 module.exports = {
-
   /**
    * Add sinon-chai and chai-jquery bower libraries during testing
    * @returns {Promise} a promise when the `ember-cli-build.js` file has been updated
@@ -27,40 +26,6 @@ module.exports = {
     })
   },
 
-  /**
-   * This very hacky workaround is to solve the following problem:
-   * @see {@link https://github.com/testem/testem/issues/1043}
-   * We install a specific version of `testem` (currently from github.com/job13er/testem#ember-frost-test)
-   * But `ember-cli` will still have it's own version, so we need to create a `postinstall` npm script that will
-   * remove the `node_modules/ember-cli/node_modules/testem` directory, letting `ember-cli` use the
-   * `node_modules/testem` version instead.
-   *
-   * NOTE: once https://github.com/testem/testem/pull/1045 is merged/released and the version of `ember-cli`
-   * we are using is picking it up, we can remove this and switch to something that makes sure that particular
-   * script is gone.
-   *
-   * @returns {Promise} a promise when the `package.json` file has been updated
-   */
-  addPostInstallScript: function () {
-    const content = '    "postinstall": "rm -rf node_modules/ember-cli/node_modules/testem",'
-    return this.insertIntoFile('package.json', content, {
-      after: '  "scripts": {' + EOL
-    })
-  },
-
-  /**
-   * This very hacky workaround since specifying a packaged as github org / repo doesn't seem to update
-   * `package.json` properly, so in the meantime we just add it to `devDependencies` manually
-   *
-   * @returns {Promise} a promise when the `package.json` file has been updated
-   */
-  addTestemDepToPackageJson: function () {
-    const content = '    "testem": "job13er/testem#ember-frost-test",'
-    return this.insertIntoFile('package.json', content, {
-      after: '  "devDependencies": {' + EOL
-    })
-  },
-
   afterInstall: function () {
     const addonsToAdd = {
       packages: [
@@ -71,10 +36,6 @@ module.exports = {
       ]
     }
 
-    const npmPackagesToAdd = [
-      {name: 'job13er/testem#ember-frost-test'}
-    ]
-
     const bowerPackagesToAdd = [
       {name: 'sinon-chai', target: '^2.8.0'},
       {name: 'chai-jquery', target: '^2.0.1'}
@@ -82,28 +43,16 @@ module.exports = {
 
     return this.addAddonsToProject(addonsToAdd)
       .then(() => {
-        return this.addPackagesToProject(npmPackagesToAdd)
-      })
-      .then(() => {
-        this.ui.writeLine(chalk.green('Updating') + ' "package.json" to include forked "testem" (for now)')
-        return this.addTestemDepToPackageJson()
-      })
-      .then(() => {
         return this.addBowerPackagesToProject(bowerPackagesToAdd)
       })
       .then(() => {
         this.ui.writeLine(chalk.green('Updating') + ' "ember-cli-build.js" to load "sinon-chai" and "chai-jquery"')
         return this.addLoadingOfTestHelpers()
       })
-      .then(() => {
-        this.ui.writeLine(chalk.green('Updating') + ' "package.json" with "postinstall" script')
-        return this.addPostInstallScript()
-      })
   },
 
   normalizeEntityName: function () {
     // this prevents an error when the entityName is
-    // not specified (since that doesn't actually matter
-    // to us
+    // not specified (since that doesn't actually matter to us)
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "lint": "npm run lint-js",
     "lint-js": "eslint addon app blueprints config tests *.js",
     "start": "ember server",
-    "test": "npm run lint && ember test",
-    "postinstall": "rm -rf node_modules/ember-cli/node_modules/testem"
+    "test": "npm run lint && ember test"
   },
   "repository": {
     "type": "git",
@@ -52,8 +51,7 @@
     "ember-welcome-page": "^1.0.3",
     "eslint": "^3.0.0",
     "eslint-config-frost-standard": "^5.0.0",
-    "loader.js": "^4.0.10",
-    "testem": "job13er/testem#ember-frost-test"
+    "loader.js": "^4.0.10"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

 * **Removed** the `blueprint` hack to install a fork of `testem` and clear out the one under `node_modules/ember-cli/node_modules/testem` since [the fix has been released](https://github.com/testem/testem/releases/tag/v1.14.1)
