### PR TITLE
Move our blueprints from npm dep to blueprints

### DIFF
--- a/blueprints/ember-frost-test/index.js
+++ b/blueprints/ember-frost-test/index.js
@@ -63,6 +63,7 @@ module.exports = {
 
     const addonsToAdd = {
       packages: [
+        {name: 'ember-cli-frost-blueprints', target: '^1.0.0'},
         {name: 'ember-cli-mocha', target: '^0.14.0'},
         {name: 'ember-hook', target: '^1.3.5'},
         {name: 'ember-sinon', target: '^0.7.0'},

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-chai": "^0.4.0",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-frost-blueprints": "^1.0.0",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
@@ -59,8 +60,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.7",
-    "ember-cli-babel": "^5.1.7",
-    "ember-cli-frost-blueprints": "^1.0.0"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "after": "ember-frost-core",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
 * **Moved** `ember-cli-frost-blueprints` from `dependencies` in `package.json` to being installed as a blueprint. It turns out that [`ember-cli` cheats w.r.t. `ember-cli-legacy-blueprints`](https://github.com/ember-cli/ember-cli/blob/v2.8.0/lib/models/project.js#L347) and so we can't follow that pattern (of just making it an `npm` dep). 
