### PR TITLE
Add chalk as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.7",
+    "chalk": "^2.3.0",
     "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG
* Add `chalk@^2.3.0` as **dependency** (was missed in #40)